### PR TITLE
Update json5 to 2.2.3 to fix vulnerabilities in v1 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babelrc"
   ],
   "dependencies": {
-    "json5": "^0.5.1",
+    "json5": "^2.2.3",
     "path-exists": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This package is heavily used, and unfortunately, over 50% of downloads are still using the 1.2.0 version which has a vulnerability in the version of json5 it is using. This was patched in version 2.0 of this library, but so many people are stuck on 1.2.0 it would be great to release a patch version just removing this critical vulnerability. This commit is based off the 1.2.0 tag. 

![Screenshot 2024-04-10 at 6 36 03 PM](https://github.com/tleunen/find-babel-config/assets/17480686/5b5cf8fa-8a44-4733-afeb-6dd42b715711)
